### PR TITLE
Re-enable mingw-w64-x86_64-graphene package

### DIFF
--- a/maint/devops.yml
+++ b/maint/devops.yml
@@ -7,4 +7,4 @@ native:
       - graphene
   msys2-mingw64:
     packages:
-      #- mingw-w64-x86_64-graphene
+      - mingw-w64-x86_64-graphene


### PR DESCRIPTION
It has been updated

- to use meson as of <https://github.com/Alexpux/MINGW-packages/commit/a6d59691c4401f7853931e34de3afdd361b0f354>
- up to v1.8.0 as of <https://github.com/Alexpux/MINGW-packages/commit/3980de1d5920e468e2a9b78ae7cc2aeb44677435>

These changes bring graphene up to the latest release and enable
gobject-introspection by default.